### PR TITLE
fix: correct path to telegram script

### DIFF
--- a/templates/capitalcraft/js/script.js
+++ b/templates/capitalcraft/js/script.js
@@ -56,7 +56,8 @@
         }
 
         var fd = new FormData(form);
-        fetch('templates/capitalcraft/sendToTelegram.php', {
+        // корректный путь к скрипту отправки данных в Telegram
+        fetch('templates/capitalcraft/send_to_telegram.php', {
           method: 'POST',
           body: fd,
         })


### PR DESCRIPTION
## Summary
- fix path to telegram send script

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68864b6a1b58832e8936cf09cef310dd